### PR TITLE
Support transients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@
 
 <br>
 
+## 0.8.0
+2024-11-3
+### Removed 
+Entries with a boolean value in the return value of `lasertag.core/tag-map`:<br>
+  - `:carries-meta?` 
+  - `:coll-type?` 
+  - `:map-like?` 
+  - `:set-like?` 
+  - `:transient?` 
+  - `:number-type?` 
+  - `:java-lang-class?` 
+  - `:java-util-class?` 
+  - `:js-object?`
+  - `:js-array?`
+  
+### Added
+The following tags are conditionally added to the :all-tags entry (hashset) in
+the return value of `lasertag.core/tag-map`:<br>
+  - `:carries-meta` 
+  - `:coll-type` 
+  - `:map-like` 
+  - `:set-like` 
+  - `:transient` 
+  - `:number-type` 
+  - `:java-lang-class` 
+  - `:java-util-class` 
+  - `:js-object`
+  - `:js-array`
+```
+
+
+<br>
+
 ## 0.7.0
 2024-11-3
 ### Added

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.paintparty/lasertag "0.7.0"
+(defproject io.github.paintparty/lasertag "0.8.0"
   :description "Clojure(Script) utility for discerning types of values."
   :url "https://github.com/paintparty/lasertag"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/lasertag/cljs_interop.cljs
+++ b/src/lasertag/cljs_interop.cljs
@@ -1,3 +1,6 @@
+;; TODO - Should demos be functions that create new Errors and instances ?
+;;        Or maybe just quoted lists?
+
 (ns lasertag.cljs-interop
   (:require 
    ;; keep these commented out unless you are doing code gen with fns at end of this namespace

--- a/src/lasertag/core.cljc
+++ b/src/lasertag/core.cljc
@@ -474,11 +474,21 @@
                     (type x)))))
 
 #?(:clj
-   (defn- java-util-class? [s]
-     (boolean (some-> s (string/starts-with? "java.util")))))
-#?(:clj
-   (defn- java-lang-class? [s]
-     (boolean (some->> s (re-find #"java\.lang")))))
+   (do
+     (defn- java-util-class? [s]
+       (boolean (some-> s (string/starts-with? "java.util"))))
+
+     (defn- java-lang-class? [s]
+       (boolean (some->> s (re-find #"java\.lang"))))
+     
+     (defn java-class-name [x]
+       (some-> x
+               type
+               .getName
+               ;; Example of what these last 2 do:
+               ;; "[Ljava.lang.Object;" -> "Ljava.lang.Object"
+               (string/replace #"^\[" "")
+               (string/replace #";$" "")))))
 
 ;; TODO - Add array-like? and maybe list-like?
 (defn- all-tags [x k dom-node-type-keyword]
@@ -520,13 +530,7 @@
         classname    #?(:cljs
                         nil
                         :clj
-                        (some-> x
-                                type
-                                .getName
-                                ;; Example of what these last 2 do:
-                                ;; "[Ljava.lang.Object;" -> "Ljava.lang.Object"
-                                (string/replace #"^\[" "")
-                                (string/replace #";$" "")))]
+                        (java-class-name x))]
     (merge 
      {:all-tags         all-tags
       :coll-type?       coll-type?

--- a/src/lasertag/core.cljc
+++ b/src/lasertag/core.cljc
@@ -358,21 +358,24 @@
                           (some #(when (keyword? %) %))))
          (when (js-object-instance? x)
            :js/map-like-object)))
-     
+
+     (defn- js-classname [x]
+       (let [k (if-let [c (.-constructor x)] 
+                 (let [nm (.-name c)]
+                   (if-not (string/blank? nm)
+                     ;; js class instances
+                     (let [ret (keyword nm)]
+                       (if (= ret :Object) :js/Object ret))
+
+                     ;; cljs datatype and recordtype instances
+                     (some-> c pwos keyword)))
+                 :js/Object)]
+         k))
+
      (defn- js-object-instance [x] 
        #?(:cljs 
           (when (js-object-instance? x)
-            (let [k (if-let [c (.-constructor x)] 
-                      (let [nm (.-name c)]
-                        (if-not (string/blank? nm)
-                    ;; js class instances
-                          (let [ret (keyword nm)]
-                            (if (= ret :Object) :js/Object ret))
-
-                    ;; cljs datatype and recordtype instances
-                          (some-> c pwos keyword)))
-                      :js/Object)]
-              k))))))
+            (js-classname x))))))
 
 
 (def dom-node-types

--- a/src/lasertag/core.cljc
+++ b/src/lasertag/core.cljc
@@ -470,11 +470,26 @@
   (if (false? (k opts)) false true))
 
 #?(:cljs 
-   (defn- cljs-coll-type? [x]
-     (or (array? x)
-         (object? x)
-         (contains? cljs-interop/js-built-ins-which-are-iterables
-                    (type x)))))
+   (do
+     (defn- cljs-coll-type? [x]
+       (or (array? x)
+           (object? x)
+           (contains? cljs-interop/js-built-ins-which-are-iterables
+                      (type x))))
+
+     (defn- cljs-class-name [x]
+       (let [ret (or (js-object-instance x)
+                     ;; TODO - test whether this one is faster
+                     (some->> (get cljs-interop/js-built-ins-by-built-in
+                                   (type x)
+                                   nil)
+                              :sym
+                              name
+                              (str "js/"))
+                     ;; TODO - or this one is faster
+                     ;; TODO - test this with custom classes
+                     (js-classname x))]
+         (if (keyword? ret) (subs (str ret) 1) ret)))))
 
 #?(:clj
    (do


### PR DESCRIPTION
Closes #6 
Closes #7
Closes #8

### Removed 
Entries with a boolean value in the return value of `lasertag.core/tag-map`:<br>
  - `:carries-meta?` 
  - `:coll-type?` 
  - `:map-like?` 
  - `:set-like?` 
  - `:transient?` 
  - `:number-type?` 
  - `:java-lang-class?` 
  - `:java-util-class?` 
  - `:js-object?`
  - `:js-array?`
  
### Added
The following tags are conditionally added to the :all-tags entry (hashset) in
the return value of `lasertag.core/tag-map`:<br>
  - `:carries-meta` 
  - `:coll-type` 
  - `:map-like` 
  - `:set-like` 
  - `:transient` 
  - `:number-type` 
  - `:java-lang-class` 
  - `:java-util-class` 
  - `:js-object`
  - `:js-array`
```